### PR TITLE
Fix transform directory copy into container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y poppler-utils
 ADD requirements.txt /app/requirements.txt
 
 ADD server.py /app/server.py
-ADD transform /app
+ADD transform /app/transform
 ADD startup.sh /app/startup.sh
 
 RUN mkdir -p /app/tmp


### PR DESCRIPTION
Previous to this fix the contents of the transform directory were
being copied into the app directory. This fix copies the transform
directory to /app/transform.