### PR TITLE
Determine dates prior to template rendering

### DIFF
--- a/transform/templates/csv.tmpl
+++ b/transform/templates/csv.tmpl
@@ -1,5 +1,5 @@
 {% filter trim_final_newline -%}
 {% for image in images -%}
-{{creation_time|format_date}},{{IMAGE_PATH}}\{{image}},{{creation_time|format_date('short')}},{{image|scan_id}},{{response.survey_id}},{{response.collection.instrument_id}},{{response.metadata.ru_ref|statistical_unit_id}},{{response.collection.period|format_period}},{{loop.index|format_page}}
+{{creation_time.long}},{{IMAGE_PATH}}\{{image}},{{creation_time.short}},{{image|scan_id}},{{response.survey_id}},{{response.collection.instrument_id}},{{response.metadata.ru_ref|statistical_unit_id}},{{response.collection.period|format_period}},{{loop.index|format_page}}
 {% endfor %}
 {%- endfilter %}

--- a/transform/transformers/ImageTransformer.py
+++ b/transform/transformers/ImageTransformer.py
@@ -91,7 +91,6 @@ class ImageTransformer(object):
         with open(os.path.join(self.path, self.index_file), "w") as fh:
             fh.write(template_output)
 
-
     def create_zip(self):
         '''
         Create a zip from a renumbered sequence

--- a/transform/transformers/ImageTransformer.py
+++ b/transform/transformers/ImageTransformer.py
@@ -76,7 +76,7 @@ class ImageTransformer(object):
         env = get_env()
         template = env.get_template('csv.tmpl')
 
-        current_time = datetime.datetime.now()
+        current_time = datetime.datetime.utcnow()
         creation_time = {
             'short': format_date(current_time, 'short'),
             'long': format_date(current_time)
@@ -90,6 +90,7 @@ class ImageTransformer(object):
 
         with open(os.path.join(self.path, self.index_file), "w") as fh:
             fh.write(template_output)
+
 
     def create_zip(self):
         '''

--- a/transform/transformers/ImageTransformer.py
+++ b/transform/transformers/ImageTransformer.py
@@ -77,10 +77,14 @@ class ImageTransformer(object):
         template = env.get_template('csv.tmpl')
 
         current_time = datetime.datetime.now()
+        creation_time = {
+            'short': format_date(current_time, 'short'),
+            'long': format_date(current_time)
+        }
         submission_date = dateutil.parser.parse(self.response['submitted_at'])
         submission_date_str = format_date(submission_date, 'short')
 
-        template_output = template.render(IMAGE_PATH=settings.IMAGE_PATH, images=self.images, response=self.response, creation_time=current_time)
+        template_output = template.render(IMAGE_PATH=settings.IMAGE_PATH, images=self.images, response=self.response, creation_time=creation_time)
 
         self.index_file = "EDC_%s_%s_%04d.csv" % (self.survey['survey_id'], submission_date_str, self.sequence_no)
 

--- a/transform/views/image_filters.py
+++ b/transform/views/image_filters.py
@@ -1,12 +1,16 @@
 import os
 from jinja2 import Environment, PackageLoader
+import arrow
 
 
 def format_date(value, style='long'):
     """convert a datetime to a different format."""
 
-    date_format = '%Y%m%d' if style == 'short' else '%d/%m/%Y %H:%M:%S'
-    return value.strftime(date_format)
+    timezone = 'Europe/London'
+    if style is 'short':
+        return arrow.get(value).to(timezone).format("YYYYMMDD")
+    else:
+        return arrow.get(value).to(timezone).format("DD/MM/YYYY HH:mm:ss")
 
 
 def statistical_unit_id_filter(value):


### PR DESCRIPTION
**Changes**

Don't pass date objects to template to be evaluated via a filter. Instead return strings and pass to template as a dict.

**How to test**

Check that times rendered in the csv file are correct. (Previously the long format was reporting the wrong HH:MM:SS.

**Who can test**

Anyone but @iwootten