### PR TITLE
Use same paragraph style for questions/answers

### DIFF
--- a/transform/transformers/PDFTransformer.py
+++ b/transform/transformers/PDFTransformer.py
@@ -99,6 +99,6 @@ class PDFTransformer(object):
                 answer = ''
                 if question['question_id'] in self.response['data']:
                     answer = self.response['data'][question['question_id']]
-                table_data.append([Paragraph(question['text'], styleN), answer])
+                table_data.append([Paragraph(question['text'], styleN), Paragraph(answer, styleN)])
 
         return table_data


### PR DESCRIPTION
**Changes**

Format answers as paragraphs with default styling within table. Fixes #24.



**How to test**

Use as part of a compose setup and send a payload for 112 with a huge comment (add a data item with 146 or 147 q_code and a large string).

**Who worked on this**

@iwootten

![screen shot 2016-09-21 at 16 14 48](https://cloud.githubusercontent.com/assets/3598161/18717068/b5d4cad6-8016-11e6-8aa9-3ebbb8ebaa73.png)