### PR TITLE
Add label in order to render comments

### DIFF
--- a/transform/surveys/023.0205.json
+++ b/transform/surveys/023.0205.json
@@ -7,6 +7,7 @@
     {
       "title": "Comments",
       "questions": [{
+        "text": "Please explain any movements in your data e.g. sale held, branches opened or sold, extreme weather, or temporary closure of shop",
         "question_id": "146",
         "type": "contains"
       }]


### PR DESCRIPTION
I have added a label to display comments' content in form 0205. The expected result can be seen in the following screenshot:

<img width="662" alt="screen shot 2016-10-24 at 16 38 12" src="https://cloud.githubusercontent.com/assets/4721929/19652349/5eb91822-9a08-11e6-9a19-7e564aa37d9b.png">

To test it:
- open sdx-console,
- load 023.0205.json survey,
- within the "Data to send" text area assign "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec et mattis elit, porta blandit sapien." to the 146 key,
- click the Submit button,
- from the Receiver section click on the Images tab and open the most recent image.