### PR TITLE
Add survey id key to form_ids dict to support non unique form ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Support non-unique survey ids
 
 ### 2.0.1 2017-03-17
   - Change env var read from `FTP_HOST` to `FTP_PATH`

--- a/tests/test_pck_transformer.py
+++ b/tests/test_pck_transformer.py
@@ -1,0 +1,47 @@
+import unittest
+
+from transform.transformers import PCKTransformer
+
+
+class TestPckTransformer(unittest.TestCase):
+
+
+    def test_get_cs_form_id_passes(self):
+        survey = {'survey_id': '023'}
+        response = {'collection': {'instrument_id': '0102'}}
+        pck_transformer = PCKTransformer(survey, response)
+        form_id = pck_transformer.get_cs_form_id()
+
+        self.assertEqual(form_id, 'RSI5B', msg=None)
+
+        survey = {'survey_id': '139'}
+        response = {'collection': {'instrument_id': '0001'}}
+        pck_transformer = PCKTransformer(survey, response)
+        form_id = pck_transformer.get_cs_form_id()
+
+        self.assertEqual(form_id, 'Q01B', msg=None)
+
+    def test_get_cs_form_id_invalid_survey(self):
+        survey = {'survey_id': 23}
+        response = {'collection': {'instrument_id': '0102'}}
+        pck_transformer = PCKTransformer(survey, response)
+
+        with self.assertLogs(level='ERROR') as cm:
+            form_id = pck_transformer.get_cs_form_id()
+            self.assertEqual(form_id, None)
+
+            msg = "ERROR:transform.transformers.PCKTransformer:Invalid survey id '23'"
+            self.assertEqual(msg, cm.output[0])
+
+    def test_get_cs_form_id_invalid_instrument(self):
+        survey = {'survey_id': '023'}
+        response = {'collection': {'instrument_id': '000'}}
+        pck_transformer = PCKTransformer(survey, response)
+
+        with self.assertLogs(level='ERROR') as cm:
+            form_id = pck_transformer.get_cs_form_id()
+            self.assertEqual(form_id, None)
+
+            msg = "ERROR:transform.transformers.PCKTransformer:Invalid instrument id '000'"
+            self.assertEqual(msg, cm.output[0])
+

--- a/transform/transformers/PCKTransformer.py
+++ b/transform/transformers/PCKTransformer.py
@@ -51,13 +51,13 @@ class PCKTransformer(object):
             form_type = self.form_types[self.survey['survey_id']]
         except KeyError:
             logger.error("Invalid survey id '{}'".format(self.survey['survey_id']))
-            return 'XXXXXX'
+            return None
 
         try:
             form_id = form_type[instrument_id]
         except KeyError:
             logger.error("Invalid instrument id '{}'".format(instrument_id))
-            return 'XXXXXX'
+            return None
 
         return form_id
 

--- a/transform/transformers/PCKTransformer.py
+++ b/transform/transformers/PCKTransformer.py
@@ -4,13 +4,15 @@ import dateutil.parser
 
 class PCKTransformer(object):
     form_ids = {
-        "0102": "RSI5B",
-        "0112": "RSI6B",
-        "0203": "RSI7B",
-        "0205": "RSI9B",
-        "0213": "RSI8B",
-        "0215": "RSI10B",
-        "0001": "Q01B"
+        "023": {
+            "0102": "RSI5B",
+            "0112": "RSI6B",
+            "0203": "RSI7B",
+            "0205": "RSI9B",
+            "0213": "RSI8B",
+            "0215": "RSI10B",
+        },
+        "0001": "Q01B",
     }
 
     def __init__(self, survey, response_data):
@@ -39,8 +41,7 @@ class PCKTransformer(object):
 
     def get_cs_form_id(self):
         instrument_id = self.response['collection']['instrument_id']
-
-        return self.form_ids[instrument_id]
+        return self.form_ids[self.survey['survey_id']][instrument_id]
 
     def get_subdate_str(self):
         submission_date = dateutil.parser.parse(self.response['submitted_at'])


### PR DESCRIPTION
Add survey id as a key to the `form_ids` dictionary.

@tundish can you give this a look over to make sure it doesn't break anything else - you know this service much better than me!