### PR TITLE
Feature/fix sequence number defaulting in image receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
   - Support non-unique survey ids
+  - Fix sequence number bug in MWSS survey
 
 ### 2.0.1 2017-03-17
   - Change env var read from `FTP_HOST` to `FTP_PATH`

--- a/tests/test_mwss_transform.py
+++ b/tests/test_mwss_transform.py
@@ -88,7 +88,7 @@ class OpTests(unittest.TestCase):
             },
             "submitted_at": "2017-04-12T13:01:26Z",
         }
-        tfr = MWSSTransformer(response)
+        tfr = MWSSTransformer(response, 0, 0)
         self.assertTrue(tfr)
 
 
@@ -460,7 +460,7 @@ class BatchFileTests(unittest.TestCase):
                 "user_id": "123456789",
                 "ru_ref": "12345678901A"
             }
-        })
+        }, batch_nr=0, seq_nr=0)
         rv = Survey.load_survey(ids)
         self.assertIsNotNone(rv)
 
@@ -476,7 +476,7 @@ class BatchFileTests(unittest.TestCase):
                 "user_id": "123456789",
                 "ru_ref": "12345678901A"
             }
-        })
+        }, batch_nr=0, seq_nr=0)
         rv = Survey.load_survey(ids)
         self.assertIsNone(rv)
 
@@ -509,7 +509,7 @@ class BatchFileTests(unittest.TestCase):
         src = pkg_resources.resource_string(__name__, "replies/eq-mwss.json")
         reply = json.loads(src.decode("utf-8"))
         reply["tx_id"] = "27923934-62de-475c-bc01-433c09fd38b8"
-        ids = Survey.identifiers(reply, batch_nr=3866)
+        ids = Survey.identifiers(reply, batch_nr=3866, seq_nr=0)
         rv = CSFormatter.idbr_receipt(**ids._asdict())
         self.assertEqual("12346789012:A:134:201605", rv)
 
@@ -518,7 +518,7 @@ class BatchFileTests(unittest.TestCase):
         reply = json.loads(src.decode("utf-8"))
         reply["tx_id"] = "27923934-62de-475c-bc01-433c09fd38b8"
         reply["collection"]["period"] = "200911"
-        ids = Survey.identifiers(reply)
+        ids = Survey.identifiers(reply, batch_nr=0, seq_nr=0)
         self.assertIsInstance(ids, Survey.Identifiers)
         self.assertEqual(0, ids.batch_nr)
         self.assertEqual(0, ids.seq_nr)
@@ -542,7 +542,7 @@ class BatchFileTests(unittest.TestCase):
             ("0140", 124),
             ("0151", 217222)
         ])
-        ids = Survey.identifiers(reply, batch_nr=3866)
+        ids = Survey.identifiers(reply, batch_nr=3866, seq_nr=0)
         rv = CSFormatter.pck_lines(reply["data"], **ids._asdict())
         self.assertEqual([
             "FV          ",
@@ -554,6 +554,22 @@ class BatchFileTests(unittest.TestCase):
 
 
 class PackingTests(unittest.TestCase):
+
+    def test_requires_batch_nr(self):
+        self.assertRaises(
+            TypeError,
+            MWSSTransformer,
+            {},
+            seq_nr=0
+        )
+
+    def test_requires_seq_nr(self):
+        self.assertRaises(
+            TypeError,
+            MWSSTransformer,
+            {},
+            batch_nr=0
+        )
 
     def test_tempdir(self):
         response = {
@@ -570,7 +586,7 @@ class PackingTests(unittest.TestCase):
             "submitted_at": "2017-04-12T13:01:26Z",
             "data": {}
         }
-        tfr = MWSSTransformer(response)
+        tfr = MWSSTransformer(response, 0, 0)
         self.assertEqual(
             "REC1204_0000.DAT",
             CSFormatter.idbr_name(
@@ -598,7 +614,7 @@ class PackingTests(unittest.TestCase):
             "data": {}
         }
         seq_nr = 12345
-        tfr = MWSSTransformer(response, seq_nr=seq_nr)
+        tfr = MWSSTransformer(response, 0, seq_nr=seq_nr)
         zf = zipfile.ZipFile(tfr.pack(img_seq=itertools.count()))
         fn = next(i for i in zf.namelist() if os.path.splitext(i)[1] == ".csv")
         bits = os.path.splitext(fn)[0].split("_")

--- a/tests/test_mwss_transform.py
+++ b/tests/test_mwss_transform.py
@@ -597,9 +597,9 @@ class PackingTests(unittest.TestCase):
             "submitted_at": "2017-04-12T13:01:26Z",
             "data": {}
         }
-        tfr = MWSSTransformer(response)
         seq_nr = 12345
-        zf = zipfile.ZipFile(tfr.pack(img_seq=itertools.repeat(seq_nr)))
+        tfr = MWSSTransformer(response, seq_nr=seq_nr)
+        zf = zipfile.ZipFile(tfr.pack(img_seq=itertools.count()))
         fn = next(i for i in zf.namelist() if os.path.splitext(i)[1] == ".csv")
         bits = os.path.splitext(fn)[0].split("_")
         self.assertEqual(seq_nr, int(bits[-1]))

--- a/tests/test_mwss_transform.py
+++ b/tests/test_mwss_transform.py
@@ -2,7 +2,9 @@ from collections import OrderedDict
 import datetime
 import itertools
 import json
+import os.path
 import unittest
+import zipfile
 
 import pkg_resources
 
@@ -579,3 +581,25 @@ class PackingTests(unittest.TestCase):
             tfr.pack(img_seq=itertools.count())
         except KeyError:
             self.fail("TODO: define pages of survey.")
+
+    def test_image_sequence_number(self):
+        response = {
+            "survey_id": "134",
+            "tx_id": "27923934-62de-475c-bc01-433c09fd38b8",
+            "collection": {
+                "instrument_id": "0005",
+                "period": "201704"
+            },
+            "metadata": {
+                "user_id": "123456789",
+                "ru_ref": "12345678901A"
+            },
+            "submitted_at": "2017-04-12T13:01:26Z",
+            "data": {}
+        }
+        tfr = MWSSTransformer(response)
+        seq_nr = 12345
+        zf = zipfile.ZipFile(tfr.pack(img_seq=itertools.repeat(seq_nr)))
+        fn = next(i for i in zf.namelist() if os.path.splitext(i)[1] == ".csv")
+        bits = os.path.splitext(fn)[0].split("_")
+        self.assertEqual(seq_nr, int(bits[-1]))

--- a/tests/test_pck_transformer.py
+++ b/tests/test_pck_transformer.py
@@ -5,7 +5,6 @@ from transform.transformers import PCKTransformer
 
 class TestPckTransformer(unittest.TestCase):
 
-
     def test_get_cs_form_id_passes(self):
         survey = {'survey_id': '023'}
         response = {'collection': {'instrument_id': '0102'}}
@@ -44,4 +43,3 @@ class TestPckTransformer(unittest.TestCase):
 
             msg = "ERROR:transform.transformers.PCKTransformer:Invalid instrument id '000'"
             self.assertEqual(msg, cm.output[0])
-

--- a/transform/transformers/ImageTransformer.py
+++ b/transform/transformers/ImageTransformer.py
@@ -111,7 +111,7 @@ class ImageTransformer(object):
             response=self.response,
             creation_time=creation_time
         )
-        
+
         msg = "Adding image to index"
         [self.logger.info(msg, file=(image_path + os.path.basename(i))) for i in images]
 

--- a/transform/transformers/MWSSTransformer.py
+++ b/transform/transformers/MWSSTransformer.py
@@ -437,7 +437,7 @@ class MWSSTransformer:
             doc.build(PDFTransformer.get_elements(survey, self.response))
 
             # Create page images from PDF
-            img_tfr = ImageTransformer(self.log, survey, self.response)
+            img_tfr = ImageTransformer(self.log, survey, self.response, self.ids.seq_nr)
             images = list(img_tfr.create_image_sequence(fp, nmbr_seq=img_seq))
             for img in images:
                 f_name = os.path.basename(img)

--- a/transform/transformers/MWSSTransformer.py
+++ b/transform/transformers/MWSSTransformer.py
@@ -100,7 +100,7 @@ class Survey:
             return None
 
     @staticmethod
-    def identifiers(data, batch_nr=0, seq_nr=0, log=None):
+    def identifiers(data, batch_nr, seq_nr, log=None):
         """Parse common metadata from the survey.
 
         Return a named tuple which code can use to access ids, etc.
@@ -395,10 +395,10 @@ class MWSSTransformer:
         zip_bytes.seek(0)
         return zip_bytes
 
-    def __init__(self, response, seq_nr=0, log=None):
+    def __init__(self, response, batch_nr, seq_nr, log=None):
         """Create a transformer object to process a survey response."""
         self.response = response
-        self.ids = Survey.identifiers(response, seq_nr=seq_nr)
+        self.ids = Survey.identifiers(response, batch_nr=batch_nr, seq_nr=seq_nr)
 
         if self.ids is None:
             raise UserWarning("Missing identifiers")
@@ -454,7 +454,7 @@ class MWSSTransformer:
 
 def run():
     reply = json.load(sys.stdin)
-    tfr = MWSSTransformer(reply)
+    tfr = MWSSTransformer(reply, 0, 0)
     zipfile = tfr.pack(img_seq=itertools.count())
     sys.stdout.buffer.write(zipfile.read())
 

--- a/transform/views/main.py
+++ b/transform/views/main.py
@@ -165,7 +165,7 @@ def render_images():
 @app.route('/common-software', methods=['POST'])
 @app.route('/common-software/<sequence_no>', methods=['POST'])
 @app.route('/common-software/<sequence_no>/<batch_number>', methods=['POST'])
-def common_software(sequence_no=1000, batch_number=False):
+def common_software(sequence_no=1000, batch_number=0):
     survey_response = request.get_json(force=True)
 
     if batch_number:
@@ -181,7 +181,7 @@ def common_software(sequence_no=1000, batch_number=False):
     survey_id = survey_response.get("survey_id")
     try:
         if survey_id == "134":
-            tfr = MWSSTransformer(survey_response, sequence_no, log=logger)
+            tfr = MWSSTransformer(survey_response, batch_number, sequence_no, log=logger)
             zipfile = tfr.pack()
         else:
             ctransformer = CSTransformer(


### PR DESCRIPTION
This fixes the following issue seen in MWSS survey:
Image receipt files (names of the form EDC_134_YYYYMMDD_XXXX.csv where XXXX is a sequence number) were being created with sequence number stuck at 1000.

This was because MWSSTransformer failed to pass the sequence number to ImageTransformer.
ImageTransformer defaults to 1000.