### PR TITLE
Remove unneeded codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,0 @@
-codecov:
-  branch: develop


### PR DESCRIPTION
Config isn't needed as codecov will use the default branch anyhow (and this config is out of date now repo uses `master` as default)