### PR TITLE
Remove require hashes from pip install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Remove pip `--require-hashes` requirement
 
 ### 2.6.0 2017-08-23
   - Update sdx-common version

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PDFTOPPM := $(shell command -v pdftoppm 2> /dev/null)
 
 build:
-	pip3 install --require-hashes -r requirements.txt
+	pip3 install -r requirements.txt
 
 test:
 	pip3 install -r test_requirements.txt


### PR DESCRIPTION
## What? and Why?
> What does this pull request change/fix? Why was it necessary?

Some dependent libraries don't have their dependencies pinned with hashes so the `--require-hashes` switch on `pip` fails


## Checklist
  - [ ] CHANGELOG.md updated? (if required)
