### PR TITLE
Fixing index file time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Fix incorrect index date time
 
 ### 2.11.0 2017-11-01
   - Removed unchanging configurable variables.

--- a/tests/test_image_transformer.py
+++ b/tests/test_image_transformer.py
@@ -68,7 +68,7 @@ class ImageTransformTests(unittest.TestCase):
             data = fb.read()
         reply = json.loads(data)
 
-        with open("./tests/data/134.0005.json", encoding="utf-8") as fb:
+        with open("./tests/data/134.0005.json") as fb:
             survey_data = fb.read()
         survey = json.loads(survey_data)
 

--- a/tests/test_image_transformer.py
+++ b/tests/test_image_transformer.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import logging
 import os.path
+import time
 import tempfile
 import unittest
 from structlog import wrap_logger
@@ -13,6 +14,8 @@ from reportlab.platypus import SimpleDocTemplate
 from transform.transformers.ImageTransformer import ImageTransformer
 from transform.transformers.PDFTransformer import PDFTransformer
 
+log = wrap_logger(logging.getLogger(__name__))
+
 
 class ImageTransformTests(unittest.TestCase):
 
@@ -22,14 +25,50 @@ class ImageTransformTests(unittest.TestCase):
     def tearDown(self):
         self.maxDiff = self.max_diff
 
+    def test_image_index_date(self):
+
+        with open("./tests/csv/valid.023.0205.json") as fb:
+            data = fb.read()
+        reply = json.loads(data)
+
+        with open("./transform/surveys/023.0205.json") as fb:
+            survey_data = fb.read()
+        survey = json.loads(survey_data)
+
+        with tempfile.TemporaryDirectory(prefix="sdx_") as location:
+            # Build PDF
+            fp = os.path.join(location, "pages.pdf")
+            doc = SimpleDocTemplate(fp, pagesize=A4)
+            pdf_transformer = PDFTransformer(survey, reply)
+            doc.build(pdf_transformer.get_elements())
+
+            # Create page images from PDF
+            img_tfr = ImageTransformer(log, survey, reply)
+            images = list(img_tfr.create_image_sequence(fp, nmbr_seq=itertools.count()))
+
+            image_transformer = ImageTransformer(log, survey, reply)
+
+            # create the index file and capture creation date
+            with open(image_transformer.create_image_index(images), "r") as fh:
+                csv = fh.read()
+                date1 = csv.split(',')[0]
+
+            time.sleep(1)
+
+            # create the index file again and make sure the date is different
+            with open(image_transformer.create_image_index(images), "r") as fh:
+                csv = fh.read()
+                date2 = csv.split(',')[0]
+
+            self.assertNotEqual(date1, date2, "Image index dates should not be equal")
+
     def test_mwss_index(self):
-        log = wrap_logger(logging.getLogger(__name__))
 
         with open("./tests/data/eq-mwss.json") as fb:
             data = fb.read()
         reply = json.loads(data)
 
-        with open("./tests/data/134.0005.json") as fb:
+        with open("./tests/data/134.0005.json", encoding="utf-8") as fb:
             survey_data = fb.read()
         survey = json.loads(survey_data)
 

--- a/transform/transformers/ImageTransformer.py
+++ b/transform/transformers/ImageTransformer.py
@@ -91,12 +91,16 @@ class ImageTransformer(object):
             os.rename(imageFile, fp)
             yield fp
 
-    def create_image_index(self, images, current_time=datetime.datetime.utcnow()):
+    def create_image_index(self, images, current_time=None):
         '''
         Takes a list of images and creates a index csv from them
         '''
         if not images:
             return None
+
+        if current_time is None:
+            current_time = datetime.datetime.utcnow()
+
         env = get_env()
         template = env.get_template('csv.tmpl')
 


### PR DESCRIPTION
The index file time is stuck at 2nd Nov (the last prod deployment) this is due to the python gotcha default parameters are cached at definition time not re-evaluated on function call.

## What? and Why?
> What does this pull request change/fix? Why was it necessary?

## Checklist
  - [ ] CHANGELOG.md updated? (if required)
