### PR TITLE
Impute zero values for MWSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Impute zero values for MWSS gross pay breakdown questions when the respondent has confirmed they are zero
 
 ### 3.2.0 2018-03-22
   - Impute zero values for RSI and QBS total questions when the respondent has confirmed they are zero

--- a/tests/test_mwss_transform.py
+++ b/tests/test_mwss_transform.py
@@ -778,6 +778,69 @@ class TransformTests(unittest.TestCase):
         return_value = MWSSTransformer.transform({"220w5": "25"})
         self.assertIs(True, return_value["220"])
 
+    def test_imputed_zero_values_weekly(self):
+        """
+        Breakdown figures (60, 70, 80) are imputed with zero when the respondent
+        has confirmed the total (50) is zero.
+        """
+        return_value = MWSSTransformer.transform({"d50": "Yes"})
+        self.assertEqual(0, return_value["50"])
+        self.assertEqual(0, return_value["60"])
+        self.assertEqual(0, return_value["70"])
+        self.assertEqual(0, return_value["80"])
+
+    def test_imputed_zero_values_fortnightly(self):
+        """
+        Breakdown figures (60, 70, 80) are imputed with zero when the respondent
+        has confirmed the total (50f) is zero.
+        """
+        return_value = MWSSTransformer.transform({"d50f": "Yes"})
+        self.assertEqual(0, return_value["50"])
+        self.assertEqual(0, return_value["60"])
+        self.assertEqual(0, return_value["70"])
+        self.assertEqual(0, return_value["80"])
+
+    def test_imputed_zero_values_weekly_and_fortnightly(self):
+        """
+        Breakdown figures (60, 70, 80) are imputed with zero when the respondent
+        has confirmed the totals (50, 50f) are zero.
+        """
+        return_value = MWSSTransformer.transform({"d50": "Yes", "d50f": "Yes"})
+        self.assertEqual(0, return_value["50"])
+        self.assertEqual(0, return_value["60"])
+        self.assertEqual(0, return_value["70"])
+        self.assertEqual(0, return_value["80"])
+
+    def test_imputed_zero_values_monthly(self):
+        """
+        Breakdown figures (171, 181) are imputed with zero when the respondent
+        has confirmed the total (151) is zero.
+        """
+        return_value = MWSSTransformer.transform({"d151": "Yes"})
+        self.assertEqual(0, return_value["151"])
+        self.assertEqual(0, return_value["171"])
+        self.assertEqual(0, return_value["181"])
+
+    def test_imputed_zero_values_fourweekly(self):
+        """
+        Breakdown figures (172, 182) are imputed with zero when the respondent
+        has confirmed the total (152) is zero.
+        """
+        return_value = MWSSTransformer.transform({"d152": "Yes"})
+        self.assertEqual(0, return_value["152"])
+        self.assertEqual(0, return_value["172"])
+        self.assertEqual(0, return_value["182"])
+
+    def test_imputed_zero_values_fiveweekly(self):
+        """
+        Breakdown figures (173, 183) are imputed with zero when the respondent
+        has confirmed the total (153) is zero.
+        """
+        return_value = MWSSTransformer.transform({"d153": "Yes"})
+        self.assertEqual(0, return_value["153"])
+        self.assertEqual(0, return_value["173"])
+        self.assertEqual(0, return_value["183"])
+
 
 class BatchFileTests(unittest.TestCase):
 

--- a/transform/transformers/mwss_transformer.py
+++ b/transform/transformers/mwss_transformer.py
@@ -102,6 +102,19 @@ class MWSSTransformer(Transformer):
             if i is not None
         ))
         mandatory = set([Decimal("130"), Decimal("131"), Decimal("132")])
+
+        if 'd50' in data or 'd50f' in data:
+            mandatory.update([Decimal("50"), Decimal("60"), Decimal("70"), Decimal("80")])
+
+        if 'd151' in data:
+            mandatory.update([Decimal("151"), Decimal("171"), Decimal("181")])
+
+        if 'd152' in data:
+            mandatory.update([Decimal("152"), Decimal("172"), Decimal("182")])
+
+        if 'd153' in data:
+            mandatory.update([Decimal("153"), Decimal("173"), Decimal("183")])
+
         return OrderedDict(
             (question_id, funct(question_id, data, default, survey))
             for question_id, (default, funct) in MWSSTransformer.ops().items()


### PR DESCRIPTION
## What? and Why?
MWSS is changing to route around the total gross pay breakdown questions when the total is zero. New q_codes will be present for each pay pattern if the total is zero and the breakdown questions have been routed around:
```
weekly - d50
fortnightly - d50f
monthly - d151
four weekly - d152
five weekly - d153
```
As the downstream systems require answers for the breakdown questions this pull request imputes zero values for these q_codes when the new q_codes are present.

If `d50` or `d50f` is present, `50`, `60`, `70` and `80` are imputed with zero
If `d151` is present, `151`, `171`, and `181` are imputed with zero
If `d152` is present, `152`, `172`, and `182` are imputed with zero
If `d153` is present, `153`, `173`, and `183` are imputed with zero

## How to test
- Fire up console and test variations of the above. A base MWSS test json can be found in `tests/data/eq-mwss.json`
- Check that the pck files have zero values for the imputed q_codes
- Check that the image doesn't display the imputed answers