### PR TITLE
Mbs 0203

### DIFF
--- a/tests/replies/009.0203.json
+++ b/tests/replies/009.0203.json
@@ -1,0 +1,24 @@
+{
+    "origin": "uk.gov.ons.edc.eq",
+    "survey_id": "009",
+    "tx_id": "40e659ec-013f-4993-9a31-ec1e0ad37888",
+    "data": {
+        "11": "13/02/2017",
+        "12": "14/03/2018",
+        "110": "256",
+        "146": "Yes",
+        "146h": "Other"
+    },
+    "type": "uk.gov.ons.edc.eq:surveyresponse",
+    "version": "0.0.1",
+    "metadata": {
+        "user_id": "K5O86M2NU1",
+        "ru_ref": "12346789012A"
+    },
+    "submitted_at": "2017-03-01T14:25:46.101447+00:00",
+    "collection": {
+        "period": "201605",
+        "exercise_sid": "82R1VDWN74",
+        "instrument_id": "0255"
+    }
+}

--- a/tests/replies/009.0203.json
+++ b/tests/replies/009.0203.json
@@ -19,6 +19,6 @@
     "collection": {
         "period": "201605",
         "exercise_sid": "82R1VDWN74",
-        "instrument_id": "0255"
+        "instrument_id": "0203"
     }
 }

--- a/tests/replies/009.0255.json
+++ b/tests/replies/009.0255.json
@@ -1,0 +1,38 @@
+{
+    "origin": "uk.gov.ons.edc.eq",
+    "survey_id": "009",
+    "tx_id": "40e659ec-013f-4993-9a31-ec1e0ad37888",
+    "data": {
+        "11": "13/02/2017",
+        "12": "14/03/2018",
+        "40": "100499.49",
+        "49": "150500",
+        "50": "12",
+        "51": "1",
+        "52": "2",
+        "53": "3",
+        "54": "4",
+        "90": "2900",
+        "146": "Yes",
+        "146a": "Change in level of business activity",
+        "146b": "In-store / online promotions",
+        "146c": "Special events (e.g. sporting events)",
+        "146d": "Calendar events (e.g. Christmas, Easter, Bank Holiday)",
+        "146e": "Weather",
+        "146f": "Store closures",
+        "146g": "Store openings",
+        "146h": "Other"
+    },
+    "type": "uk.gov.ons.edc.eq:surveyresponse",
+    "version": "0.0.1",
+    "metadata": {
+        "user_id": "K5O86M2NU1",
+        "ru_ref": "12346789012A"
+    },
+    "submitted_at": "2017-03-01T14:25:46.101447+00:00",
+    "collection": {
+        "period": "201605",
+        "exercise_sid": "82R1VDWN74",
+        "instrument_id": "0255"
+    }
+}

--- a/tests/replies/009.0255.json
+++ b/tests/replies/009.0255.json
@@ -13,6 +13,7 @@
         "53": "3",
         "54": "4",
         "90": "2900",
+        "110": "256",
         "146": "Yes",
         "146a": "Change in level of business activity",
         "146b": "In-store / online promotions",

--- a/tests/test_mbs_transformer.py
+++ b/tests/test_mbs_transformer.py
@@ -1,44 +1,33 @@
+import json
 import unittest
 
 from transform.transformers import MBSTransformer
 from transform.transformers.cs_formatter import CSFormatter
 
+class 0203LogicTests(unittest.TestCase):
 
-class LogicTests(unittest.TestCase):
+    with open('tests/replies/009.0203.json', 'r') as fp:
+        response = json.load(fp)
 
-    response = {
-        "origin": "uk.gov.ons.edc.eq",
-        "survey_id": "009",
-        "tx_id": "40e659ec-013f-4993-9a31-ec1e0ad37888",
-        "data": {
-            "11": "13/02/2017",
-            "12": "14/03/2018",
-            "146": "Yes",
-            "146a": "Change in level of business activity",
-            "146b": "In-store / online promotions",
-            "146c": "Special events (e.g. sporting events)",
-            "146d": "Calendar events (e.g. Christmas, Easter, Bank Holiday)",
-            "146e": "Weather",
-            "146f": "Store closures",
-            "146g": "Store openings",
-            "146h": "Other",
-            "40": "100499.49",
-            "49": "150500",
-            "90": "2900",
-            "50": "12",
-            "51": "1",
-            "52": "2",
-            "53": "3",
-            "54": "4",
-        },
-        "type": "uk.gov.ons.edc.eq:surveyresponse",
-        "version": "0.0.1",
-        "metadata": {"user_id": "K5O86M2NU1", "ru_ref": "12346789012A"},
-        "submitted_at": "2017-03-01T14:25:46.101447+00:00",
-        "collection": {
-            "period": "201605", "exercise_sid": "82R1VDWN74", "instrument_id": "0255"
-        },
-    }
+    transformed_data = MBSTransformer(response).transform()
+
+    def test_turnover_radio(self):
+        """
+        QId 146 returns Yes.
+        """
+        self.assertEqual(self.transformed_data["146"], 1)
+
+        no_response = dict.copy(self.response)
+        no_response["data"]["146"] = "No"
+        no_response_transformed = MBSTransformer(no_response).transform()
+
+        self.assertEqual(no_response_transformed["146"], False)
+
+
+class 0255LogicTests(unittest.TestCase):
+
+    with open('tests/replies/009.0255.json', 'r') as fp:
+        response = json.load(fp)
 
     transformed_data = MBSTransformer(response).transform()
 

--- a/tests/test_mbs_transformer.py
+++ b/tests/test_mbs_transformer.py
@@ -188,8 +188,11 @@ class LogicTests(unittest.TestCase):
         """
         Qid d12 is Yes and no Qid 11 or 12
         """
-        self.transformed_no_default_data["11"] is None
-        self.transformed_no_default_data["12"] is None
+        with self.assertRaises(KeyError):
+            self.transformed_no_default_data["11"] is None
+
+        with self.assertRaises(KeyError):
+            self.transformed_no_default_data["12"] is None
 
 
 class BatchFileTests(unittest.TestCase):

--- a/tests/test_mbs_transformer.py
+++ b/tests/test_mbs_transformer.py
@@ -4,36 +4,10 @@ import unittest
 from transform.transformers import MBSTransformer
 from transform.transformers.cs_formatter import CSFormatter
 
-class LogicTests0203(unittest.TestCase):
 
-    with open('tests/replies/009.0203.json', 'r') as fp:
-        response = json.load(fp)
+class LogicTests(unittest.TestCase):
 
-    transformed_data = MBSTransformer(response).transform()
-
-    def test_turnover_radio(self):
-        """
-        QId 146 returns Yes.
-        """
-        self.assertEqual(self.transformed_data["146"], 1)
-
-        no_response = dict.copy(self.response)
-        no_response["data"]["146"] = "No"
-        no_response_transformed = MBSTransformer(no_response).transform()
-
-        self.assertEqual(no_response_transformed["146"], False)
-
-
-    def test_110(self):
-        """
-        QId 110 returns a whole number as a string.
-        """
-        self.assertEqual(self.transformed_data["110"], "256")
-
-
-class LogicTests0255(unittest.TestCase):
-
-    with open('tests/replies/009.0255.json', 'r') as fp:
+    with open("tests/replies/009.0255.json", "r") as fp:
         response = json.load(fp)
 
     transformed_data = MBSTransformer(response).transform()
@@ -51,6 +25,12 @@ class LogicTests0255(unittest.TestCase):
     # in the PCK file
     del default_response["data"]["d50"]
     transformed_no_default_data = MBSTransformer(default_response).transform()
+
+    def test_potable_water(self):
+        """
+        QId 110 returns a whole number as a string.
+        """
+        self.assertEqual(self.transformed_data["110"], "256")
 
     def test_reporting_period_from(self):
         """
@@ -122,77 +102,77 @@ class LogicTests0255(unittest.TestCase):
         """
         self.assertEqual(self.transformed_data["50"], "12")
 
-    def test_q51(self):
+    def test_male_employees_working_more_than_30(self):
         """
         QId 51 returns an integer.
         """
         self.assertEqual(self.transformed_data["51"], 1)
 
-    def test_q51_not_supplied_is_None(self):
+    def test_male_employees_working_more_than_30_not_supplied_is_None(self):
         """
         QId 51 defaults to None if 'd50' is not 'Yes'.
         """
         with self.assertRaises(KeyError):
-            _ = self.transformed_no_default_data["51"]
+            self.transformed_no_default_data["51"]
 
-    def test_q51_default(self):
+    def test_male_employees_working_more_than_30_default(self):
         """
         QId 51 defaults to 0 if 'd50' is 'Yes'.
         """
         self.assertEqual(self.transformed_default_data["51"], 0)
 
-    def test_q52(self):
+    def test_male_employees_working_less_than_30(self):
         """
         QId 52 returns an integer.
         """
         self.assertEqual(self.transformed_data["52"], 2)
 
-    def test_q52_not_supplied_is_None(self):
+    def test_male_employees_working_less_than_30_not_supplied_is_None(self):
         """
         QId 52 defaults to None if 'd50' is not 'Yes'.
         """
         with self.assertRaises(KeyError):
-            _ = self.transformed_no_default_data["52"]
+            self.transformed_no_default_data["52"]
 
-    def test_q52_default(self):
+    def test_male_employees_working_less_than_30_default(self):
         """
         QId 52 defaults to 0 if 'd50' is 'Yes'.
         """
         self.assertEqual(self.transformed_default_data["52"], 0)
 
-    def test_q53(self):
+    def test_female_employees_working_more_than_30(self):
         """
         QId 53 returns an integer.
         """
         self.assertEqual(self.transformed_data["53"], 3)
 
-    def test_q53_not_supplied_is_None(self):
+    def test_female_employees_working_more_than_30_not_supplied_is_None(self):
         """
         QId 53 defaults to None if 'd50' is not 'Yes'.
         """
         with self.assertRaises(KeyError):
-            _ = self.transformed_no_default_data["53"]
+            self.transformed_no_default_data["53"]
 
-    def test_q53_default(self):
+    def test_female_employees_working_more_than_30_default(self):
         """
         QId 53 defaults to 0 if 'd50' is 'Yes'.
         """
         self.assertEqual(self.transformed_default_data["53"], 0)
 
-    def test_q54(self):
+    def test_female_employees_working_less_than_30(self):
         """
         QId 54 returns an integer.
         """
         self.assertEqual(self.transformed_data["54"], 4)
 
-    def test_q54_not_supplied_is_None(self):
+    def test_female_employees_working_more_less_30_not_supplied_is_None(self):
         """
         QId 54 defaults to None if 'd50' is not 'Yes'.
         """
         with self.assertRaises(KeyError):
-            _ = self.transformed_no_default_data["54"]
+            self.transformed_no_default_data["54"]
 
-    def test_q54_default(self):
+    def test_female_employees_working_more_less_30_default(self):
         """
         QId 54 defaults to 0 if 'd50' is 'Yes'.
         """

--- a/tests/test_mbs_transformer.py
+++ b/tests/test_mbs_transformer.py
@@ -4,7 +4,7 @@ import unittest
 from transform.transformers import MBSTransformer
 from transform.transformers.cs_formatter import CSFormatter
 
-class 0203LogicTests(unittest.TestCase):
+class LogicTests0203(unittest.TestCase):
 
     with open('tests/replies/009.0203.json', 'r') as fp:
         response = json.load(fp)
@@ -24,7 +24,14 @@ class 0203LogicTests(unittest.TestCase):
         self.assertEqual(no_response_transformed["146"], False)
 
 
-class 0255LogicTests(unittest.TestCase):
+    def test_110(self):
+        """
+        QId 110 returns a whole number as a string.
+        """
+        self.assertEqual(self.transformed_data["110"], "256")
+
+
+class LogicTests0255(unittest.TestCase):
 
     with open('tests/replies/009.0255.json', 'r') as fp:
         response = json.load(fp)

--- a/tests/test_mbs_transformer.py
+++ b/tests/test_mbs_transformer.py
@@ -133,7 +133,7 @@ class LogicTests0255(unittest.TestCase):
         QId 51 defaults to None if 'd50' is not 'Yes'.
         """
         with self.assertRaises(KeyError):
-            self.transformed_no_default_data["51"]
+            _ = self.transformed_no_default_data["51"]
 
     def test_q51_default(self):
         """
@@ -152,7 +152,7 @@ class LogicTests0255(unittest.TestCase):
         QId 52 defaults to None if 'd50' is not 'Yes'.
         """
         with self.assertRaises(KeyError):
-            self.transformed_no_default_data["52"]
+            _ = self.transformed_no_default_data["52"]
 
     def test_q52_default(self):
         """
@@ -171,7 +171,7 @@ class LogicTests0255(unittest.TestCase):
         QId 53 defaults to None if 'd50' is not 'Yes'.
         """
         with self.assertRaises(KeyError):
-            self.transformed_no_default_data["53"]
+            _ = self.transformed_no_default_data["53"]
 
     def test_q53_default(self):
         """
@@ -190,7 +190,7 @@ class LogicTests0255(unittest.TestCase):
         QId 54 defaults to None if 'd50' is not 'Yes'.
         """
         with self.assertRaises(KeyError):
-            self.transformed_no_default_data["54"]
+            _ = self.transformed_no_default_data["54"]
 
     def test_q54_default(self):
         """

--- a/transform/surveys/009.0203.json
+++ b/transform/surveys/009.0203.json
@@ -1,0 +1,58 @@
+{
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "form_type": "0203",
+    "comments": "true",
+    "question_groups": [
+        {
+            "title": "Reporting Period",
+            "questions": [
+                {
+                    "title": "What are the dates of the period that you will be reporting for?",
+                    "text": "From",
+                    "question_id": "11",
+                    "number": "11",
+                    "type": "date"
+                },
+                {
+                    "title": "What are the dates of the period that you will be reporting for?",
+                    "text": "To",
+                    "question_id": "12",
+                    "number": "12",
+                    "type": "date"
+                }
+            ]
+        },
+        {
+            "title": "Volume of potable water that was supplied to customers",
+            "questions": [
+                {
+                    "text": "Volume of potable water that was supplied to customers, in megalitres",
+                    "question_id": "110",
+                    "number": "110"
+                }
+            ]
+        },
+        {
+            "title": "Significant Changes",
+            "questions": [
+                {
+                    "text": "Did any significant changes occur?",
+                    "question_id": "146",
+                    "number": "146",
+                    "type": "radio",
+                    "options": [
+                        "Yes",
+                        "No"
+                    ]
+                },
+                {
+                    "text": "Did any significant changes occur?",
+                    "question_id": "146h",
+                    "number": "146h",
+                    "type": "contains"
+                }
+            ]
+        }
+    ]
+}

--- a/transform/transformers/mbs_transformer.py
+++ b/transform/transformers/mbs_transformer.py
@@ -36,11 +36,16 @@ class MBSTransformer():
     @staticmethod
     def round_mbs(value):
         """MBS rounding is done on a ROUND_HALF_UP basis and values are divided by 1000 for the pck"""
-        return Decimal(round(Decimal(float(value))) / 1000).quantize(1)
+        try:
+            return Decimal(round(Decimal(float(value))) / 1000).quantize(1)
+        except TypeError:
+            logger.info("Tried to quantize a NoneType object. Returning None")
+            return None
 
     def __init__(self, response, seq_nr=0):
 
-        self.idbr_ref = {"0255": "MB65B"}
+        self.idbr_ref = {"0255": "MB65B", "0203": "MB03B"}
+
         self.response = response
         self.ids = self.get_identifiers(seq_nr=seq_nr)
 
@@ -133,9 +138,14 @@ class MBSTransformer():
             "49": self.round_mbs(self.response["data"].get("49")),
             "90": self.round_mbs(self.response["data"].get("90")),
             "50": self.response["data"].get("50"),
+            "110": self.response["data"].get("110"),
         }
 
-        return self._merge_dicts(transformed_data, employee_totals)
+        return {
+            k: v
+            for k, v in self._merge_dicts(transformed_data, employee_totals).items()
+            if v is not None
+        }
 
     def create_zip(self, img_seq=None):
         """Perform transformation on the survey data


### PR DESCRIPTION
## What? and Why?
> Adds transform q codes for form type 0203 of MBS survey

To test, use sdx-compose and submit JSON conforming to the 0203 form type spec (available from `tests/replies/009.0203.json`).