### PR TITLE
Potable water should now return value submitted not 1

### DIFF
--- a/tests/test_mbs_transformer.py
+++ b/tests/test_mbs_transformer.py
@@ -34,7 +34,7 @@ class LogicTests(unittest.TestCase):
 
     def test_potable_water(self):
         """
-        QId 110 returns a whole number as a string.
+        QId 110 returns a whole number as n integer.
         """
         self.assertEqual(self.transformed_data["110"], 256)
 

--- a/tests/test_mbs_transformer.py
+++ b/tests/test_mbs_transformer.py
@@ -36,7 +36,7 @@ class LogicTests(unittest.TestCase):
         """
         QId 110 returns a whole number as a string.
         """
-        self.assertEqual(self.transformed_data["110"], "256")
+        self.assertEqual(self.transformed_data["110"], 256)
 
     def test_reporting_period_from(self):
         """

--- a/transform/transformers/mbs_transformer.py
+++ b/transform/transformers/mbs_transformer.py
@@ -195,7 +195,7 @@ class MBSTransformer():
             "49": self.round_mbs(self.response["data"].get("49")),
             "90": self.round_mbs(self.response["data"].get("90")),
             "50": MBSTransformer.convert_str_to_int(self.response["data"].get("50")),
-            "110": self.response["data"].get("110"),
+            "110": MBSTransformer.convert_str_to_int(self.response["data"].get("110"))
         }
 
         return {


### PR DESCRIPTION
## What? and Why?
> Q_code 110 should now be written to the pck as the value entered by the user, not 1

