### PR TITLE
Pass default dates downstream

### DIFF
--- a/tests/replies/009.0255.json
+++ b/tests/replies/009.0255.json
@@ -28,7 +28,9 @@
     "version": "0.0.1",
     "metadata": {
         "user_id": "K5O86M2NU1",
-        "ru_ref": "12346789012A"
+        "ru_ref": "12346789012A",
+        "ref_period_start_date": "2018-01-01",
+        "ref_period_end_date": "2018-03-01"
     },
     "submitted_at": "2017-03-01T14:25:46.101447+00:00",
     "collection": {

--- a/tests/test_mbs_transformer.py
+++ b/tests/test_mbs_transformer.py
@@ -190,10 +190,10 @@ class LogicTests(unittest.TestCase):
         Qid d12 is Yes and no Qid 11 or 12
         """
         self.assertEqual(
-            self.transformed_no_default_data["11"], datetime.datetime(2018, 1, 1, 0, 0)
+            self.transformed_no_default_data["11"], datetime.date(2018, 1, 1)
         )
         self.assertEqual(
-            self.transformed_no_default_data["12"], datetime.datetime(2018, 3, 1, 0, 0)
+            self.transformed_no_default_data["12"], datetime.date(2018, 3, 1)
         )
 
 
@@ -351,8 +351,8 @@ class TestTransform(unittest.TestCase):
         self.assertEqual(
             result,
             {
-                "11": datetime.datetime(2018, 1, 1, 0, 0),
-                "12": datetime.datetime(2018, 3, 1, 0, 0),
+                "11": datetime.date(2018, 1, 1),
+                "12": datetime.date(2018, 3, 1),
             },
         )
 

--- a/transform/transformers/mbs_transformer.py
+++ b/transform/transformers/mbs_transformer.py
@@ -243,16 +243,16 @@ class MBSTransformer():
             start_date = MBSTransformer.parse_timestamp(self.response["data"]["11"])
         except KeyError:
             logger.info("Populating start date using metadata")
-            start_date = datetime.datetime.strptime(
-                self.response.get("metadata", {})["ref_period_start_date"], "%Y-%m-%d"
+            start_date = MBSTransformer.parse_timestamp(
+                self.response.get("metadata", {})["ref_period_start_date"]
             )
 
         try:
             end_date = MBSTransformer.parse_timestamp(self.response["data"]["12"])
         except KeyError:
             logger.info("Populating end date using metadata")
-            end_date = datetime.datetime.strptime(
-                self.response.get("metadata", {})["ref_period_end_date"], "%Y-%m-%d"
+            end_date = MBSTransformer.parse_timestamp(
+                self.response.get("metadata", {})["ref_period_end_date"]
             )
 
         return {"11": start_date, "12": end_date}


### PR DESCRIPTION
## What? and Why?
> This change introduces a mechanism for putting survey reporting period start and end dates in to a PCK file, even when a respondent does not explicitly enter them. The dates are taken from a submission's metadata if they aren't present in the data field.
