### PR TITLE
Calculate values from submitted data for downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
-
+  - Added support for QCAS form types.
+  - Calculate total values for QCAS to be sent downstream.
+    
 ### 3.5.2 2018-08-09
   - Fix error in turnover rounding
 

--- a/tests/test_pck_transformer.py
+++ b/tests/test_pck_transformer.py
@@ -103,3 +103,76 @@ class TestPckTransformer(unittest.TestCase):
         pck_transformer.evaluate_confirmation_questions()
 
         self.assertEquals(pck_transformer.data, {'681': '100'})
+
+    def test_pck_transformer_calculates_total_playback_qcas(self):
+        """
+        For QCAS, downstream needs the calculated values for both acquisitions
+        and proceeds from disposals to be sent in the PCK.
+        """
+        survey = {'survey_id': '019'}
+        response = {
+            "collection": {
+                "instrument_id": "0020"
+            },
+            "data": {
+                "11": "03/07/2018",
+                "12": "01/10/2018",
+                "146": "A lot of changes.",
+                "681": "123456.78",
+                "688": "54.32",
+                "689": "12",
+                "695": "56999.1",
+                "696": "57999.9",
+                "697": "0",
+                "703": "700",
+                "704": "300",
+                "707": "100",
+                "708": "200",
+                "709": "321",
+                "710": "123",
+                "711": "987",
+                "712": "9.87",
+                "146a": "Yes",
+                "146b": "Start or end of a long term project",
+                "146c": "Site changes, for example, openings, closures, refurbishments or upgrades",
+                "146d": "End of accounting period or financial year",
+                "146e": "Normal movement for time of year",
+                "146f": "Change of business structure, merger, or takeover",
+                "146g": "One off or unusual investment",
+                "146h": "Introduction / removal of new legislation / incentive",
+                "146i": "Availability of credit",
+                "146j": "Overspend during the previous quarter",
+                "146k": "Other",
+                "d12": "Yes",
+                "d681": "Yes"
+            }
+        }
+
+        pck_transformer = PCKTransformer(survey, response)
+        pck_transformer.calculate_total_playback()
+
+        # Total value of acquisitions questions for only machinery and equipments section
+        self.assertEquals(pck_transformer.data['714'], '59161.42')
+
+        # Total value of disposals questions for only machinery and equipments section
+        self.assertEquals(pck_transformer.data['715'], '58644.77')
+
+        # Total value of all acquisitions questions
+        self.assertEquals(pck_transformer.data['692'], '182618.20')
+
+        # Total value of all disposals questions (same as '715' since constructions section and minerals sections does not have disposals question)
+        self.assertEquals(pck_transformer.data['693'], '58644.77')
+
+        pck_transformer.round_currency_values()
+
+        # Total value of acquisitions questions for only machinery and equipments section
+        self.assertEquals(pck_transformer.data['714'], '59161')
+
+        # Total value of disposals questions for only machinery and equipments section
+        self.assertEquals(pck_transformer.data['715'], '58645')
+
+        # Total value of all acquisitions questions
+        self.assertEquals(pck_transformer.data['692'], '182618')
+
+        # Total value of all disposals questions (same as '715' since constructions section and minerals sections does not have disposals question)
+        self.assertEquals(pck_transformer.data['693'], '58645')

--- a/transform/surveys/019.0018.json
+++ b/transform/surveys/019.0018.json
@@ -150,6 +150,44 @@
             ]
         },
         {
+            "title": "Total playback for machinery and equipments",
+            "questions": [
+                {
+                    "title": "The total value of acquisitions for machinery and equipments",
+                    "text": "The total value of acquisitions for machinery and equipments",
+                    "question_id": "714",
+                    "number": "714",
+                    "type": "currency"
+                },
+                {
+                    "title": "The total value of proceeds from disposals for machinery and equipments",
+                    "text": "The total value of proceeds from disposals for machinery and equipments",
+                    "question_id": "715",
+                    "number": "715",
+                    "type": "currency"
+                }
+            ]
+        },
+        {
+            "title": "Total playback for all questions",
+            "questions": [
+                {
+                    "title": "The total value of all acquisitions",
+                    "text": "The total value of all acquisitions",
+                    "question_id": "692",
+                    "number": "692",
+                    "type": "currency"
+                },
+                {
+                    "title": "The total value of all proceeds from disposals",
+                    "text": "The total value of all proceeds from disposals",
+                    "question_id": "693",
+                    "number": "693",
+                    "type": "currency"
+                }
+            ]
+        },
+        {
             "title": "Significant changes",
             "questions": [
                 {

--- a/transform/surveys/019.0019.json
+++ b/transform/surveys/019.0019.json
@@ -150,6 +150,44 @@
             ]
         },
         {
+            "title": "Total playback for machinery and equipments",
+            "questions": [
+                {
+                    "title": "The total value of acquisitions for machinery and equipments",
+                    "text": "The total value of acquisitions for machinery and equipments",
+                    "question_id": "714",
+                    "number": "714",
+                    "type": "currency"
+                },
+                {
+                    "title": "The total value of proceeds from disposals for machinery and equipments",
+                    "text": "The total value of proceeds from disposals for machinery and equipments",
+                    "question_id": "715",
+                    "number": "715",
+                    "type": "currency"
+                }
+            ]
+        },
+        {
+            "title": "Total playback for all questions",
+            "questions": [
+                {
+                    "title": "The total value of all acquisitions",
+                    "text": "The total value of all acquisitions",
+                    "question_id": "692",
+                    "number": "692",
+                    "type": "currency"
+                },
+                {
+                    "title": "The total value of all proceeds from disposals",
+                    "text": "The total value of all proceeds from disposals",
+                    "question_id": "693",
+                    "number": "693",
+                    "type": "currency"
+                }
+            ]
+        },
+        {
             "title": "Significant changes",
             "questions": [
                 {

--- a/transform/surveys/019.0020.json
+++ b/transform/surveys/019.0020.json
@@ -150,13 +150,51 @@
             ]
         },
         {
+            "title": "Total playback for machinery and equipments",
+            "questions": [
+                {
+                    "title": "The total value of acquisitions for machinery and equipments",
+                    "text": "The total value of acquisitions for machinery and equipments",
+                    "question_id": "714",
+                    "number": "714",
+                    "type": "currency"
+                },
+                {
+                    "title": "The total value of proceeds from disposals for machinery and equipments",
+                    "text": "The total value of proceeds from disposals for machinery and equipments",
+                    "question_id": "715",
+                    "number": "715",
+                    "type": "currency"
+                }
+            ]
+        },
+        {
             "title": "Mineral exploration and evaluation",
             "questions": [
                 {
-                    "title": "What was the total capital expenditure on <em>mineral exploration and evaluation?<\/em>",
+                    "title": "What was the total capital expenditure on mineral exploration and evaluation?",
                     "text": "Value of acquisitions for mineral exploration and evaluation",
                     "question_id": "697",
                     "number": "697",
+                    "type": "currency"
+                }
+            ]
+        },
+        {
+            "title": "Total playback for all questions",
+            "questions": [
+                {
+                    "title": "The total value of all acquisitions",
+                    "text": "The total value of all acquisitions",
+                    "question_id": "692",
+                    "number": "692",
+                    "type": "currency"
+                },
+                {
+                    "title": "The total value of all proceeds from disposals",
+                    "text": "The total value of all proceeds from disposals",
+                    "question_id": "693",
+                    "number": "693",
                     "type": "currency"
                 }
             ]


### PR DESCRIPTION
## What? and Why?
Adds the calculated total values for both acquisitions and proceeds from disposals into the PCK file.
This is needed by the business and downstream falls over if we don't.

## How to review
Ensure the following are present in the PCK file:

- `q_code - 692 - Total value of all acquisitions questions.`
- `q_code - 693 - Total value of all disposals questions.`
- `q_code - 714 - Total value of all acquisitions questions for only machinery and equipments sections.`
- `q_code - 715 - Total value of all disposals questions for only machinery and equipments sections.`

- the value of `714` is the sum of all values of `q_codes` - `['688', '695', '703', '707', '709', '711']`
- the value of `715` is the sum of all values of `q_codes` - `['689', '696', '704', '708', '710', '712']`
- the value of `692` is the sum of all values of `q_codes` - `['681', '689', '696', '704', '708', '710', '712']` and '697' for form type `0020`.
- the value of `693` is the same as `715`

The values are totalled before the figures are rounded.
## Checklist
  - [x] CHANGELOG.md updated? (if required)
