### PR TITLE
Ensure R3 is shown on image file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
  - Change option value for E-Commerce q-code 416 (r3)
+ - Ensure r3 is on image file
 
 ### 3.7.0 2018-12-12
   - Added support for E-commerce form and CORD surveys.

--- a/tests/test_e_commerce_transformer.py
+++ b/tests/test_e_commerce_transformer.py
@@ -275,6 +275,7 @@ class TestTransformerUnits:
             'EDC_QImages/Images/S000000004.JPG',
             'EDC_QImages/Images/S000000005.JPG',
             'EDC_QImages/Images/S000000006.JPG',
+            'EDC_QImages/Images/S000000007.JPG',
             'EDC_QImages/Index/EDC_187_20170301_0000.csv',
             'EDC_QJson/187_0000.json'
         ]

--- a/transform/surveys/187.0051.json
+++ b/transform/surveys/187.0051.json
@@ -347,28 +347,7 @@
           "question_id": "490"
         }, {
           "text": "When was the business security policy defined or most recently reviewed?",
-          "question_id": "415",
-          "number": "415",
-          "type": "radio",
-          "options": [
-              "Within the last 12 months"
-          ]
-        }, {
-          "text": "When was the business security policy defined or most recently reviewed?",
-          "question_id": "416",
-          "number": "416",
-          "type": "radio",
-          "options": [
-              "More than 12 months ago and up to 24 months ago"
-          ]
-        }, {
-          "text": "When was the business security policy defined or most recently reviewed?",
-          "question_id": "417",
-          "number": "417",
-          "type": "radio",
-          "options": [
-              "More than 24 months ago"
-          ]
+          "question_id": "r3"
         }, {
           "text": "During 2018, did any ICT security issues result in the unavailability of ICT services?",
           "question_id": "491"


### PR DESCRIPTION
## What? and Why?
> q-code r3 is not showing on image file as it's using the transformed q-codes rather than r3. This fixes that.

## Checklist
  - [ ] CHANGELOG.md updated? (if required)
