### PR TITLE
Updating dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+ - Updated the dockerfile
  - Used Python 3.5 inbuilt dictionary merging instead of merge_dicts
 
 ### 3.9.0 2019-02-19

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM onsdigital/flask-crypto-queue
 
+RUN sed -i '/jessie-updates/d' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y poppler-utils
 
 COPY server.py /app/server.py


### PR DESCRIPTION
## What? and Why?
When building the image from sdx-transform-cs, an error was occurring when trying to run `apt-get update`. The way to fix this was to add a line before it which will remove the jessie-updates from sources.list.

## To Test
- The best way to test is to purge your docker and rebuild the images
## Checklist
  - [x] CHANGELOG.md updated? (if required)
