### PR TITLE
Release 3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ### Unreleased
+
+### 3.10.0 2019-04-02
  - Update Jinja to 2.10.1 to fix a security issue.
  - Update Pillow and PyYAML versions
  - Updated the dockerfile

--- a/transform/__init__.py
+++ b/transform/__init__.py
@@ -6,8 +6,7 @@ from requests.adapters import HTTPAdapter
 app = Flask(__name__)
 
 from .views import main  # noqa
-
-__version__ = "3.9.0"
+__version__ = "3.10.0"
 
 # Configure the number of retries attempted before failing call
 session = requests.Session()


### PR DESCRIPTION
## What? and Why?

Release 3.10.0

 - Update Jinja to 2.10.1 to fix a security issue.
 - Update Pillow and PyYAML versions
 - Updated the dockerfile
 - Used Python 3.5 inbuilt dictionary merging instead of merge_dicts

## Checklist
  - [Y ] CHANGELOG.md updated? (if required)
