### PR TITLE
Rename QSI to QSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ### Unreleased
- - Add calculated totals for QSI as the totals aren't passed to SDX
- - Fix missing date qcodes (11 and 12) for QSI
- - Add formtype 0070 for QSI (Stocks)
+ - Renamed QSI (Quarterly Stocks Inquiry) to QSS (Quarterly Stocks Survey)
+ - Add calculated totals for QSS as the totals aren't passed to SDX
+ - Fix missing date qcodes (11 and 12) for QSS (Stocks)
+ - Add formtype 0070 for QSS (Stocks)
  - Change rounding to stocks to divide by 1000 after rounding (like QCAS)
 
 ### 3.10.0 2019-04-02

--- a/tests/test_pck_transformer.py
+++ b/tests/test_pck_transformer.py
@@ -98,7 +98,7 @@ class TestPckTransformer(unittest.TestCase):
     @staticmethod
     def test_pck_transformer_parse_estimation_question():
         """
-        For QSI (Stocks), qcode 15 needs to converted from Yes/No to 1/0 for the pck.
+        For QSS (Stocks), qcode 15 needs to converted from Yes/No to 1/0 for the pck.
         """
         survey = {'survey_id': '017'}
 
@@ -272,9 +272,9 @@ class TestPckTransformer(unittest.TestCase):
         assert pck_transformer.data['693'] == '12347'
 
     @staticmethod
-    def test_pck_transformer_calculates_total_playback_qsi():
+    def test_pck_transformer_calculates_total_playback_qss():
         """
-        For QSI (Stocks), downstream needs to calculate the start and end of period totals.
+        For QSS (Stocks), downstream needs to calculate the start and end of period totals.
         The fields that are added together are defined in a dictionary in the pck_transformer
         """
         scenarios = ["0001", "0002"]
@@ -312,9 +312,9 @@ class TestPckTransformer(unittest.TestCase):
                 '150': '12205'
             }
 
-    def test_pck_transformer_total_playback_qsi_missing_data_from_mapping(self):
+    def test_pck_transformer_total_playback_qss_missing_data_from_mapping(self):
         """
-        For QSI (Stocks), downstream needs to calculate the start and end of period totals.
+        For QSS (Stocks), downstream needs to calculate the start and end of period totals.
         It does this with a mapping in the pck_transformer.  If a new formtype is added but it's not
         added to the mapping or a 'start' or 'end' key isn't present then a KeyError exception is thrown.
         """
@@ -339,7 +339,7 @@ class TestPckTransformer(unittest.TestCase):
             }
 
             pck_transformer = PCKTransformer(survey, response)
-            pck_transformer.qsi_questions = {
+            pck_transformer.qss_questions = {
                 "0033": {
                     "end": ['140', '145', '150']
                 }
@@ -381,9 +381,9 @@ class TestPckTransformer(unittest.TestCase):
                 '662': '35'
             }
 
-    def test_pck_transformer_round_numeric_values_qsi(self):
+    def test_pck_transformer_round_numeric_values_qss(self):
         """
-        For QSI (Stocks), a number of values require rounding before being sent downstream. These should
+        For QSS (Stocks), a number of values require rounding before being sent downstream. These should
         be rounded to the nearest thousand.
         For example:
             - 12100 -> 12000

--- a/transform/surveys/017.0001.json
+++ b/transform/surveys/017.0001.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry",
+    "title": "Quarterly Stocks Survey",
     "survey_id": "017",
     "form_type": "0001",
     "comments": "true",

--- a/transform/surveys/017.0002.json
+++ b/transform/surveys/017.0002.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry (NI)",
+    "title": "Quarterly Stocks Survey (NI)",
     "survey_id": "017",
     "form_type": "0002",
     "comments": "true",

--- a/transform/surveys/017.0003.json
+++ b/transform/surveys/017.0003.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry",
+    "title": "Quarterly Stocks Survey",
     "survey_id": "017",
     "form_type": "0003",
     "comments": "true",

--- a/transform/surveys/017.0004.json
+++ b/transform/surveys/017.0004.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry (NI)",
+    "title": "Quarterly Stocks Survey (NI)",
     "survey_id": "017",
     "form_type": "0004",
     "comments": "true",

--- a/transform/surveys/017.0005.json
+++ b/transform/surveys/017.0005.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry",
+    "title": "Quarterly Stocks Survey",
     "survey_id": "017",
     "form_type": "0005",
     "comments": "true",

--- a/transform/surveys/017.0006.json
+++ b/transform/surveys/017.0006.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry (NI)",
+    "title": "Quarterly Stocks Survey (NI)",
     "survey_id": "017",
     "form_type": "0006",
     "comments": "true",

--- a/transform/surveys/017.0007.json
+++ b/transform/surveys/017.0007.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry",
+    "title": "Quarterly Stocks Survey",
     "survey_id": "017",
     "form_type": "0007",
     "comments": "true",

--- a/transform/surveys/017.0008.json
+++ b/transform/surveys/017.0008.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry (NI)",
+    "title": "Quarterly Stocks Survey (NI)",
     "survey_id": "017",
     "form_type": "0008",
     "comments": "true",

--- a/transform/surveys/017.0009.json
+++ b/transform/surveys/017.0009.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry",
+    "title": "Quarterly Stocks Survey",
     "survey_id": "017",
     "form_type": "0009",
     "comments": "true",

--- a/transform/surveys/017.0010.json
+++ b/transform/surveys/017.0010.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry (NI)",
+    "title": "Quarterly Stocks Survey (NI)",
     "survey_id": "017",
     "form_type": "0010",
     "comments": "true",

--- a/transform/surveys/017.0011.json
+++ b/transform/surveys/017.0011.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry",
+    "title": "Quarterly Stocks Survey",
     "survey_id": "017",
     "form_type": "0011",
     "comments": "true",

--- a/transform/surveys/017.0012.json
+++ b/transform/surveys/017.0012.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry",
+    "title": "Quarterly Stocks Survey",
     "survey_id": "017",
     "form_type": "0012",
     "comments": "true",

--- a/transform/surveys/017.0013.json
+++ b/transform/surveys/017.0013.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry",
+    "title": "Quarterly Stocks Survey",
     "survey_id": "017",
     "form_type": "0013",
     "comments": "true",

--- a/transform/surveys/017.0014.json
+++ b/transform/surveys/017.0014.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry (NI)",
+    "title": "Quarterly Stocks Survey (NI)",
     "survey_id": "017",
     "form_type": "0014",
     "comments": "true",

--- a/transform/surveys/017.0033.json
+++ b/transform/surveys/017.0033.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry",
+    "title": "Quarterly Stocks Survey",
     "survey_id": "017",
     "form_type": "0033",
     "comments": "true",

--- a/transform/surveys/017.0034.json
+++ b/transform/surveys/017.0034.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry (NI)",
+    "title": "Quarterly Stocks Survey (NI)",
     "survey_id": "017",
     "form_type": "0034",
     "comments": "true",

--- a/transform/surveys/017.0051.json
+++ b/transform/surveys/017.0051.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry",
+    "title": "Quarterly Stocks Survey",
     "survey_id": "017",
     "form_type": "0051",
     "comments": "true",

--- a/transform/surveys/017.0052.json
+++ b/transform/surveys/017.0052.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry (NI)",
+    "title": "Quarterly Stocks Survey (NI)",
     "survey_id": "017",
     "form_type": "0051",
     "comments": "true",

--- a/transform/surveys/017.0057.json
+++ b/transform/surveys/017.0057.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry",
+    "title": "Quarterly Stocks Survey",
     "survey_id": "017",
     "form_type": "0057",
     "comments": "true",

--- a/transform/surveys/017.0058.json
+++ b/transform/surveys/017.0058.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry (NI)",
+    "title": "Quarterly Stocks Survey (NI)",
     "survey_id": "017",
     "form_type": "0058",
     "comments": "true",

--- a/transform/surveys/017.0061.json
+++ b/transform/surveys/017.0061.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry",
+    "title": "Quarterly Stocks Survey",
     "survey_id": "017",
     "form_type": "0061",
     "comments": "true",

--- a/transform/surveys/017.0070.json
+++ b/transform/surveys/017.0070.json
@@ -1,5 +1,5 @@
 {
-    "title": "Quarterly Stocks Inquiry",
+    "title": "Quarterly Stocks Survey",
     "survey_id": "017",
     "form_type": "0070",
     "comments": "true",


### PR DESCRIPTION
## What? and Why?
Stocks had its name changed from QSI to QSS.  This PR changes all references to the former with the latter.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
