### PR TITLE
Added python 3.8 to travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.8"
   - "3.7"
   - "3.6"
 dist: xenial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+ - Add python 3.8 to travis builds
 
 ### 3.12.2 2019-09-26
  - Update werkzeug to 0.15.6 to fix security issue


### PR DESCRIPTION
## What? and Why?
Add python 3.8 to travis builds so we can have confidence in our system when we end up upgrading the version of python we use

## Checklist
  - [x] CHANGELOG.md updated? (if required)
