### PR TITLE
fix for ecommerce receipt

### DIFF
--- a/tests/transform/transformers/test_cord_formatter.py
+++ b/tests/transform/transformers/test_cord_formatter.py
@@ -1,0 +1,17 @@
+
+import unittest
+
+from transform.transformers.cord.cord_formatter import CORDFormatter
+
+
+class CordFormatterTests(unittest.TestCase):
+
+    def test_idbr_receipt(self):
+        period = "2019"
+        idbr = CORDFormatter.get_idbr("187", "12346789012", "A", period)
+        self.assertEqual("12346789012:A:187:201912", idbr)
+
+    def test_idbr_receipt_6_digit(self):
+        period = "201912"
+        idbr = CORDFormatter.get_idbr("187", "12346789012", "A", period)
+        self.assertEqual("12346789012:A:187:201912", idbr)

--- a/transform/transformers/cord/cord_formatter.py
+++ b/transform/transformers/cord/cord_formatter.py
@@ -24,3 +24,10 @@ class CORDFormatter(Formatter):
     def _pck_lines(data, survey_id, ru_ref, period):
         """Return a list of lines in a PCK file."""
         return [f"{ru_ref}:{survey_id}:{period}:{qcode}:{value}" for qcode, value in sorted(data.items())]
+
+    @staticmethod
+    def get_idbr(survey_id, ru_ref, ru_check, period):
+        """Write an IDBR file."""
+        # the period requires a 12 to be prefixed (to represent the month)
+        period = period + "12" if len(period) == 4 else period
+        return "{0}:{1}:{2:03}:{3}".format(ru_ref, ru_check, int(survey_id), period)


### PR DESCRIPTION
## What? and Why?
> Seems that the original requirement to prefix any 4 digit period with a "20" was incorrect. In the case of E-commerce a "12" needs to be post-fixed to any 4 digit period. 

## Checklist
  - [ ] CHANGELOG.md updated? (if required). - not required
